### PR TITLE
Constant-time Operations

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -4585,10 +4585,10 @@ constant_time_equals(x, y):
 
   result = 0
 
-  for i= 0; i < len(x); i++
-    result |= x ^ y
+  for i = 0; i < len(x); i++
+    result |= x[i] ^ y[i]
 
-  return result
+  return 1 & ~((-result) >> 8)
 ```
 
 #### Constant-time Selection
@@ -4598,7 +4598,7 @@ A constant-time selection function should return `x` if `v` is `1` and `y` if
 
 ```
 constant_time_select(v, x, y):
-  return ^(v - 1)&x | (v - 1)&y
+  return ((-v) & x) | ((v - 1) & y)
 ```
 
 ## References


### PR DESCRIPTION
* Fix equality, returned 0 if equal and non 0 if not equal. Instead of returning 1 if equal and 0 if not equal.
* Cleaned up selection and fixed the error with xor (^) vs not (~).

If these are suppose to be unsigned integers and you want to avoid a compile warning then replace `(-result)` with `(0 - result)` and `(-v)` with `(0 - v)`.