### PR TITLE
Correct state transition to AWAITING_AUTH_I.

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -3577,7 +3577,7 @@ If the state is `START`:
     * Remember the sender's instance tag to use as the receiver's instance tag
       for future messages.
     * Reply with an Auth-R message.
-    * Transition to the `WAITING_AUTH_R` state.
+    * Transition to the `WAITING_AUTH_I` state.
 
 If the state is `WAITING_AUTH_R`:
 


### PR DESCRIPTION
After receiving and processing the Identity message, it is incorrectly specified that we need to transition to state WAITING_AUTH_R, while we have also just sent an Auth-R message. Correcting to state WAITING_AUTH_I.