### PR TITLE
Adjust names/formatting in references.

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -4850,7 +4850,7 @@ Compute:
    Key Exchanges for Secure Messaging*, Waterloo, Canada: University of
    Waterloo. Available at:
    http://cacr.uwaterloo.ca/techreports/2016/cacr2016-06.pdf
-2. Perrin, T and Marlinspike, M. (2016). *The Double Ratchet Algorithm*.
+2. Perrin, T. and Marlinspike, M. (2016). *The Double Ratchet Algorithm*.
    [online]signal.org. Available at:
    https://whispersystems.org/docs/specifications/doubleratchet
 3. Bernstein, D. (2008). *Extending the Salsa20 Nonce*, Chicago,
@@ -4874,9 +4874,9 @@ Compute:
 10. Bernstein, D. and T. Lange. (2007). *Projective coordinates for Edwards
     curves*, The 'add-2007-bl' addition formulas. Available at:
     http://www.hyperelliptic.org/EFD/g1p/auto-edwards-projective.html#addition-add-2007-bl
-11. Blake-Wilson, S., Johnson, D., Menezes, A. (1997) *Key Agreement Protocols
+11. Blake-Wilson, S., Johnson, D. and Menezes, A. (1997) *Key Agreement Protocols
     and their Security Analysis*. Available at:
     https://dl.acm.org/citation.cfm?id=742138
-12. Lachlan J., Vieitez, R., Asokan, N. (2018) *On The Use of Remote Attestation
+12. Gunn, L. J., Vieitez Parra, R. and Asokan, N. (2018) *On The Use of Remote Attestation
     to Break and Repair Deniability*. Available at:
     https://eprint.iacr.org/2018/424.pdf


### PR DESCRIPTION
I have tweaked our names in the reference to our pre-print, and also taken the liberty of making the "." and final-"and" usage consistent across all of the references.