### PR TITLE
Remove incorrect mention of finished DAKE, as Bob has one more step to perform

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -2008,8 +2008,6 @@ Bob will be initiating the DAKE with Alice.
     * Securely deletes `their_ecdh` and `their_dh`.
 1. Sends Alice the Auth-I message (see [Auth-I message](#auth-i-message)
    section).
-1. At this point, the interactive DAKE is complete for Bob, but the double
-   ratchet algorithm still needs to be correctly set up.
 
 **Alice:**
 


### PR DESCRIPTION
I believe this line should have been removed with recent changes in the protocol state machine.

Okay, to be more precise. Technically, it is okay, but it also redundantly mentioned and Bob still relies on a message from Alice to be able to complete Double Ratchet. I'd prefer that the story is consistent, i.e. if we are "finished" then no extra step is mentioned later on. These are the kinds of textual things that may puzzle a new reader. The last step that explains how Bob should receive a message from Alice shortly, is far more clear.