### PR TITLE
Fix incorrect type for SMP1 TLV.

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -904,7 +904,7 @@ Type 1: Disconnected
 
 Type 2: SMP Message 1
   The value represents the initial message of the Socialist Millionaires'
-  Protocol (SMP). Note that this represents TLV type 1 and 7 from OTRv3.
+  Protocol (SMP). Note that this represents TLV type 2 and 7 from OTRv3.
   This TLV should have the 'IGNORE_UNREADABLE' flag set.
 
 Type 3: SMP Message 2


### PR DESCRIPTION
Mistake in clarifying text. It refers to OTRv3's DISCONNECT TLV, instead of the SMP1 TLV.