### PR TITLE
Fix variable references for DH integer checking.

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -589,7 +589,7 @@ should be done modulo the prime `dh_p`.
 To verify that an integer (`x`) is on the group with a 3072-bit modulus:
 
 1. Check that `x` is `>= g3` and `<= dh_p - g3`.
-1. Compute `x ^ q mod p`. If `result == 1`, the integer is a valid element.
+1. Compute `x ^ dh_q mod dh_p`. If `result == 1`, the integer is a valid element.
    Otherwise the integer is an invalid element.
 
 ### Key Derivation Functions


### PR DESCRIPTION
Fixing variable references: strictly speaking they now point to the Elliptic Curve parameters, which I suspect is not the intention.