### PR TITLE
Fine tuning double ratchet and small clarification

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -1278,6 +1278,7 @@ To rotate the brace key:
 
     * Derive and securely overwrite
       `brace_key = KDF(usage_brace_key || brace_key, 32)`.
+    * Increase `since_last_dh` by 1.
 
 ### Rotating ECDH Keys and Brace Key as receiver
 
@@ -1311,6 +1312,7 @@ To rotate the brace key:
 
     * Derive and securely overwrite
       `brace_key = KDF(usage_brace_key || brace_key, 32)`.
+    * Increase `since_last_dh` by 1.
 
 ### Deriving Double Ratchet Keys
 
@@ -1358,8 +1360,9 @@ To expire a session:
 1. Calculate the MAC keys corresponding to the stored message keys in the
    `skipped_MKenc` dictionary and put them on the `old_mac_keys` list (so they
    are revealed in TLV type 1 (Disconnected) message).
-1. Send a Disconnect message (containing a TLV type 1 with empty payload), with
-   the `old_mac_keys` list attached to it.
+1. Send a Data message containing a TLV type 1 with empty payload - this is
+   often referred to as 'Disconnected message' - with the `old_mac_keys` list
+   attached to it.
 1. Securely delete all keys and data associated with the conversation.
    This includes:
 
@@ -3237,7 +3240,6 @@ Given a new DH Ratchet:
   * Derive new set of keys:
     `curr_root_key, chain_key_s[j] = derive_ratchet_keys(sending, prev_root_key, K)`.
   * Securely delete the previous root key (`prev_root_key`) and `K`.
-  * Increments `since_last_dh = since_last_dh + 1`.
   * If present, forget and reveal MAC keys. The conditions for revealing MAC
     keys are stated in the [Revealing MAC Keys](#revealing-mac-keys) section.
   * Derive the next sending chain key, `MKenc` and `MKmac`, and encrypt the
@@ -3374,7 +3376,6 @@ The decryption mechanism works as:
   * Derive new set of keys
     `curr_root_key, chain_key_r[k] = derive_ratchet_keys(receiving, prev_root_key, K)`.
   * Securely delete the previous root key (`prev_root_key`) and `K`.
-  * Increments `since_last_dh = since_last_dh + 1`.
   * Derive the next receiving chain key, `MKenc` and `MKmac`, and decrypt the
     message as described below.
 

--- a/otrv4.md
+++ b/otrv4.md
@@ -3247,7 +3247,7 @@ Given a new DH Ratchet:
 
 When sending a data message in the same DH Ratchet:
 
-  * Set `i - 1` as the Data message's message id.
+  * Set `i - 1` as the Data message's ratchet id.
   * Set `j` as the Data message's message id.
   * Set `pn` as the Data message's previous chain message number.
   * Derive the next sending chain key
@@ -3330,8 +3330,8 @@ The decryption mechanism works as:
     * Securely delete `MKenc`.
     * Add `MKmac` to the list `mac_keys_to_reveal`.
 
-  * If `max_remote_i_seen` > `message_id`:
-    * If the received `message_id` and `Public ECDH Key` are not in the
+  * If `max_remote_i_seen` > `ratchet_id`:
+    * If the received `ratchet_id` and `Public ECDH Key` are not in the
       `skipped_MKenc` dictionary:
       * This is a duplicated message from a past DH ratchet. Discard the
          message.
@@ -3427,7 +3427,7 @@ The decryption mechanism works as:
       * Set `their_dh` as the 'Public DH Key' from the message, if it is not
         empty.
       * Add `MKmac` to the list `mac_keys_to_reveal`.
-   * Set `max_remote_i_seen` to `message_id`.
+   * Set `max_remote_i_seen` to `ratchet_id`.
 
 * If a message arrives that corresponds to a message key already deleted or that
   cannot be derived:

--- a/otrv4.md
+++ b/otrv4.md
@@ -1306,7 +1306,6 @@ To rotate the brace key:
     * Calculate `k_dh = DH(our_dh.secret, their_dh)`.
     * Calculate a `brace_key = KDF(usage_third_brace_key || k_dh, 32)`.
     * Securely delete `our_dh.secret` and `k_dh`.
-    * Set `since_last_dh` to 0.
 
   * Otherwise:
 

--- a/otrv4.md
+++ b/otrv4.md
@@ -1278,7 +1278,6 @@ To rotate the brace key:
 
     * Derive and securely overwrite
       `brace_key = KDF(usage_brace_key || brace_key, 32)`.
-    * Increase `since_last_dh` by 1.
 
 ### Rotating ECDH Keys and Brace Key as receiver
 
@@ -1312,7 +1311,6 @@ To rotate the brace key:
 
     * Derive and securely overwrite
       `brace_key = KDF(usage_brace_key || brace_key, 32)`.
-    * Increase `since_last_dh` by 1.
 
 ### Deriving Double Ratchet Keys
 
@@ -2145,7 +2143,8 @@ Bob will be initiating the DAKE with Alice.
        [When you send a Data Message](#when-you-send-a-data-message) section.
        Note that he will not perform a new DH ratchet, but rather start using
        the derived `chain_key_s[j]`. He should follow the
-       "When sending a data message in the same DH Ratchet:" subsection.
+       "When sending a data message in the same DH Ratchet:" subsection and
+        attaches his ECDH and DH public keys to this message.
    * In the case that he receives a data message:
      * Follows what is defined in the
        [When you receive a Data Message](#when-you-receive-a-data-message)
@@ -2200,7 +2199,7 @@ Bob will be initiating the DAKE with Alice.
        "When sending a data message in the same DH Ratchet:" subsection.
    * In the case that she immediately receives a data message:
      * Follows what is defined in the
-       [When you receive a Data Message](#when-you-send-a-data-message) section.
+       [When you receive a Data Message](#when-you-receive-a-data-message) section.
        Note that she will perform a new DH ratchet with the advertised keys
        from Bob attached in the message. If she wants to send data
        messages at this point (after receiving ones), she will perform a new DH
@@ -3238,6 +3237,7 @@ Given a new DH Ratchet:
   * Derive new set of keys:
     `curr_root_key, chain_key_s[j] = derive_ratchet_keys(sending, prev_root_key, K)`.
   * Securely delete the previous root key (`prev_root_key`) and `K`.
+  * Increments `since_last_dh = since_last_dh + 1`.
   * If present, forget and reveal MAC keys. The conditions for revealing MAC
     keys are stated in the [Revealing MAC Keys](#revealing-mac-keys) section.
   * Derive the next sending chain key, `MKenc` and `MKmac`, and encrypt the
@@ -3374,7 +3374,7 @@ The decryption mechanism works as:
   * Derive new set of keys
     `curr_root_key, chain_key_r[k] = derive_ratchet_keys(receiving, prev_root_key, K)`.
   * Securely delete the previous root key (`prev_root_key`) and `K`.
-  * Increment `since_last_dh` to 1.
+  * Increments `since_last_dh = since_last_dh + 1`.
   * Derive the next receiving chain key, `MKenc` and `MKmac`, and decrypt the
     message as described below.
 

--- a/otrv4.md
+++ b/otrv4.md
@@ -1358,8 +1358,8 @@ To expire a session:
 1. Calculate the MAC keys corresponding to the stored message keys in the
    `skipped_MKenc` dictionary and put them on the `old_mac_keys` list (so they
    are revealed in TLV type 1 (Disconnected) message).
-1. Send a TLV type 1 (Disconnected) message, with the `old_mac_keys` list
-   attached to it.
+1. Send a Disconnect message (containing a TLV type 1 with empty payload), with
+   the `old_mac_keys` list attached to it.
 1. Securely delete all keys and data associated with the conversation.
    This includes:
 

--- a/otrv4.md
+++ b/otrv4.md
@@ -1261,7 +1261,7 @@ To rotate the ECDH keys:
   * Generate a new ECDH key pair and assign it to `our_ecdh = generateECDH()`
     (by securely replacing the old value).
   * Calculate `K_ecdh = ECDH(our_ecdh.secret, their_ecdh)`.
-  * i = i + 1
+  * `i = i + 1`
 
 To rotate the brace key:
 


### PR DESCRIPTION
I believe the current description of the Double Ratchet algorithm has a mistake where:
1. The receiver-side increments `since_last_dh` twice, once in "Rotating keys as receiver" and once in "When you receive  ...".
2. The sender-side does not mention the increment in "When you send ...".

If I understand the algorithm correctly, then we expect to have steady `+1` increments with each ratchet.

I've added a bit of nuance to the description in session expiration to avoid that people interpret the message as saying: add the `old_mac_keys` to the TLV as payload.