### PR TITLE
Remove store-for-retransmission when already in 'ENCRYPTED' state.

### DIFF
--- a/otrv4.md
+++ b/otrv4.md
@@ -4093,7 +4093,6 @@ to send encrypted messages:
 If the state is `ENCRYPTED`:
 
   * Encrypt the message, and send it as a Data Message.
-  * Store any plaintext message for possible retransmission.
 
 #### Receiving a Data Message
 


### PR DESCRIPTION
Unnecessary line as we're already in `ENCRYPTED` state so we can simply send the message.